### PR TITLE
feat: add --depth=1

### DIFF
--- a/console/commands/new_command.go
+++ b/console/commands/new_command.go
@@ -137,7 +137,7 @@ func (r *NewCommand) generate(ctx console.Context, name string, module string) e
 	}
 
 	// clone the repository
-	clone := exec.Command("git", "clone", "https://github.com/goravel/goravel.git", path)
+	clone := exec.Command("git", "clone", "--depth=1", "https://github.com/goravel/goravel.git", path)
 	err := ctx.Spinner("Creating a \"goravel/goravel\" project at \""+name+"\"", console.SpinnerOption{
 		Action: func() error {
 			return clone.Run()


### PR DESCRIPTION
## 📑 Description

https://github.com/goravel/goravel/issues/358

<!-- Please add Review Ready tag or leave a Review Ready message when the PR is good to go -->
<!-- More description can be written after this -->
This pull request includes a small but significant change to the `generate` function in the `console/commands/new_command.go` file. The change improves the efficiency of cloning a repository by using a shallow clone.

* [`console/commands/new_command.go`](diffhunk://#diff-cf5ed1f23cd3c348b3b357a6cb73ac2c0f6116db7f76f8181e583d3e353e2401L140-R140): Modified the `clone` command to use the `--depth=1` option, which performs a shallow clone and reduces the amount of data being transferred.