### PR TITLE
fix: resolve goravel upgrade failure when current directory is not a Go module

### DIFF
--- a/console/commands/upgrade_command.go
+++ b/console/commands/upgrade_command.go
@@ -35,11 +35,12 @@ func (r *UpgradeCommand) Extend() command.Extend {
 // Handle Execute the console command.
 func (r *UpgradeCommand) Handle(ctx console.Context) error {
 	pkg := support.InstallerModuleName
-	if version := ctx.Argument(0); version != "" {
-		pkg = pkg + "@" + version
+	version := ctx.Argument(0)
+	if version == "" {
+		version = "latest"
 	}
 
-	upgrade := exec.Command("go", "install", pkg)
+	upgrade := exec.Command("go", "install", pkg+"@"+version)
 	if err := ctx.Spinner(fmt.Sprintf("> @%s", strings.Join(upgrade.Args, " ")), console.SpinnerOption{
 		Action: func() error {
 			output, err := upgrade.CombinedOutput()

--- a/console/commands/upgrade_command_test.go
+++ b/console/commands/upgrade_command_test.go
@@ -5,12 +5,12 @@ import (
 	"io"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 	"github.com/goravel/framework/contracts/console"
 	consolemocks "github.com/goravel/framework/mocks/console"
 	"github.com/goravel/framework/support/color"
 	"github.com/goravel/installer/support"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 )
 
 func TestUpgradeCommand(t *testing.T) {
@@ -28,9 +28,9 @@ func TestUpgradeCommand(t *testing.T) {
 	mockContext.EXPECT().Spinner(
 		fmt.Sprintf("> @go install %s@unknown", support.InstallerModuleName),
 		mock.AnythingOfType("console.SpinnerOption")).
-			RunAndReturn(func(_ string, option console.SpinnerOption) error {
-				return option.Action()
-			}).Once()
+		RunAndReturn(func(_ string, option console.SpinnerOption) error {
+			return option.Action()
+		}).Once()
 	captureOutput := color.CaptureOutput(func(w io.Writer) {
 		assert.NoError(t, upgradeCommand.Handle(mockContext))
 	})
@@ -40,7 +40,7 @@ func TestUpgradeCommand(t *testing.T) {
 	//upgrade success
 	mockContext.EXPECT().Argument(0).Return("").Once()
 	mockContext.EXPECT().Spinner(
-		fmt.Sprintf("> @go install %s", support.InstallerModuleName),
+		fmt.Sprintf("> @go install %s@latest", support.InstallerModuleName),
 		mock.AnythingOfType("console.SpinnerOption")).Return(nil).Once()
 	captureOutput = color.CaptureOutput(func(w io.Writer) {
 		assert.NoError(t, upgradeCommand.Handle(mockContext))


### PR DESCRIPTION
## 📑 Description

Closes https://github.com/goravel/goravel/issues/

<img width="866" alt="image" src="https://github.com/user-attachments/assets/5cdfdf2b-7be7-420f-8048-9b1743664c11" />


<!-- Please add Review Ready tag or leave a Review Ready message when the PR is good to go -->
<!-- More description can be written after this -->

## ✅ Checks

<!-- Make sure your PR passes the CI checks and do check the following fields as needed - -->
- [x] Added test cases for my code
