### PR TITLE
Loosen module regexp match and correct version string

### DIFF
--- a/console/commands/new_command.go
+++ b/console/commands/new_command.go
@@ -137,8 +137,8 @@ func (r *NewCommand) Handle(ctx console.Context) (err error) {
 			return nil
 		}
 	}
-	if !regexp.MustCompile(`^[a-zA-Z0-9./_-]+$`).MatchString(module) {
-		color.Errorln("invalid module name format. Use only letters, numbers, dots (.), slashes (/), underscores (_), and hyphens (-). Example: [github.com/yourusername/yourproject] or [yourproject]")
+	if !regexp.MustCompile(`^[a-zA-Z0-9./_-~]+$`).MatchString(module) {
+		color.Errorln("invalid module name format. Use only letters, numbers, dots (.), slashes (/), underscores (_), hyphens (-), and tildes (~). Example: [github.com/yourusername/yourproject] or [yourproject]")
 		return nil
 	}
 

--- a/console/commands/new_command_test.go
+++ b/console/commands/new_command_test.go
@@ -56,14 +56,14 @@ func TestNewCommand(t *testing.T) {
 	mockContext.EXPECT().Ask("What is the module name?", mock.Anything).Return("invalid:module", nil).Once()
 	assert.Contains(t, color.CaptureOutput(func(w io.Writer) {
 		assert.Nil(t, newCommand.Handle(mockContext))
-	}), "invalid module name format. Use only letters, numbers, dots (.), slashes (/), underscores (_), and hyphens (-). Example: [github.com/yourusername/yourproject] or [yourproject]")
+	}), "invalid module name format. Use only letters, numbers, dots (.), slashes (/), underscores (_), hyphens (-), and tildes (~). Example: [github.com/yourusername/yourproject] or [yourproject]")
 
 	mockContext.EXPECT().Argument(0).Return("example-app").Once()
 	mockContext.EXPECT().OptionBool("force").Return(true).Once()
 	mockContext.EXPECT().Option("module").Return("invalid:module").Once()
 	assert.Contains(t, color.CaptureOutput(func(w io.Writer) {
 		assert.Nil(t, newCommand.Handle(mockContext))
-	}), "invalid module name format. Use only letters, numbers, dots (.), slashes (/), underscores (_), and hyphens (-). Example: [github.com/yourusername/yourproject] or [yourproject]")
+	}), "invalid module name format. Use only letters, numbers, dots (.), slashes (/), underscores (_), hyphens (-), and tildes (~). Example: [github.com/yourusername/yourproject] or [yourproject]")
 
 	mockContext.EXPECT().Argument(0).Return("example-app").Once()
 	mockContext.EXPECT().OptionBool("force").Return(true).Once()

--- a/support/constant.go
+++ b/support/constant.go
@@ -1,6 +1,6 @@
 package support
 
-const Version string = "v1.1.2"
+const Version string = "v1.4.1"
 
 const WelcomeHeading = `
    ___   ___   ___    _ __   __ ___  _    


### PR DESCRIPTION
## 📑 Description

This closes out two seperate tickets, first is the installer doesn't accept the URL pattern used by source forges like SourceHut that uses tildes (~) in the URL. The second is the hardcoded `Version` constant is behind.

Closes https://github.com/goravel/installer/issues/49
Closes https://github.com/goravel/installer/issues/50

<!-- Please add Review Ready tag or leave a Review Ready message when the PR is good to go -->
<!-- More description can be written after this -->

## ✅ Checks

<!-- Make sure your PR passes the CI checks and do check the following fields as needed - -->
- [x] Added test cases for my code
