### PR TITLE
feat: add agent skills installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,22 @@ go install github.com/goravel/installer/goravel@latest
 goravel new blog
 ```
 
+## Skills
+
+```bash
+# Install all Goravel agent skills to ~/.agents/skills
+goravel skill:install
+
+# Install all Goravel agent skills to a custom folder
+goravel skill:install --path ~/goravel-skills
+
+# Install specific skills
+goravel skill:install goravel-testing goravel-planning
+
+# Overwrite existing skills
+goravel skill:install --force goravel-testing
+```
+
 ## Upgrade
 
 ```bash

--- a/app/console/commands/skill_install_command.go
+++ b/app/console/commands/skill_install_command.go
@@ -1,0 +1,299 @@
+package commands
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/goravel/framework/contracts/console"
+	"github.com/goravel/framework/contracts/console/command"
+	"github.com/goravel/framework/support/color"
+	"github.com/goravel/framework/support/file"
+
+	"github.com/goravel/installer/app/facades"
+)
+
+const agentsRepo = "https://github.com/goravel/agents.git"
+
+type SkillInstallCommand struct{}
+
+func NewSkillInstallCommand() *SkillInstallCommand {
+	return &SkillInstallCommand{}
+}
+
+// Signature The name and signature of the console command.
+func (r *SkillInstallCommand) Signature() string {
+	return "skill:install"
+}
+
+// Description The console command description.
+func (r *SkillInstallCommand) Description() string {
+	return "Install Goravel agent skills"
+}
+
+// Extend The console command extend.
+func (r *SkillInstallCommand) Extend() command.Extend {
+	return command.Extend{
+		ArgsUsage: " [skills...]",
+		Arguments: []command.Argument{
+			&command.ArgumentStringSlice{
+				Name:  "skills",
+				Usage: "The skills to install. Installs all skills when omitted",
+				Min:   0,
+				Max:   -1,
+			},
+		},
+		Flags: []command.Flag{
+			&command.StringFlag{
+				Name:    "path",
+				Aliases: []string{"p"},
+				Usage:   "The destination skills folder",
+			},
+			&command.BoolFlag{
+				Name:               "force",
+				Aliases:            []string{"f"},
+				Usage:              "Overwrite existing skills",
+				DisableDefaultText: true,
+			},
+		},
+	}
+}
+
+// Handle Execute the console command.
+func (r *SkillInstallCommand) Handle(ctx console.Context) error {
+	destination, err := r.getDestination(ctx)
+	if err != nil {
+		color.Errorln(err)
+		return nil
+	}
+
+	installed, skipped, err := r.installSkills(destination, ctx.ArgumentStringSlice("skills"), ctx.OptionBool("force"))
+	if err != nil {
+		color.Errorln(err)
+		return nil
+	}
+
+	if installed > 0 {
+		color.Successf("Installed %d Goravel skill(s) to %s\n", installed, destination)
+	}
+	if skipped > 0 {
+		color.Warnf("Skipped %d existing Goravel skill(s). Use --force to overwrite.\n", skipped)
+	}
+
+	return nil
+}
+
+func (r *SkillInstallCommand) getDestination(ctx console.Context) (string, error) {
+	destination := ctx.Option("path")
+	if destination == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("failed to get home directory: %w", err)
+		}
+
+		destination = filepath.Join(home, ".agents", "skills")
+	} else {
+		expanded, err := expandHomePath(destination)
+		if err != nil {
+			return "", err
+		}
+		destination = expanded
+	}
+
+	destination, err := filepath.Abs(destination)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve skills path: %w", err)
+	}
+
+	return destination, nil
+}
+
+func (r *SkillInstallCommand) installSkills(destination string, skillNames []string, force bool) (int, int, error) {
+	tmpDir, err := os.MkdirTemp("", "goravel-agents-*")
+	if err != nil {
+		return 0, 0, fmt.Errorf("failed to create temp directory: %w", err)
+	}
+	defer func() {
+		_ = os.RemoveAll(tmpDir)
+	}()
+
+	repoPath := filepath.Join(tmpDir, "agents")
+	if err := r.cloneAgents(repoPath); err != nil {
+		return 0, 0, err
+	}
+
+	skillsPath := filepath.Join(repoPath, "skills")
+	skills, err := r.resolveSkills(skillsPath, skillNames)
+	if err != nil {
+		return 0, 0, err
+	}
+	if len(skills) == 0 {
+		return 0, 0, errors.New("no skills found in goravel/agents")
+	}
+
+	if err := os.MkdirAll(destination, 0755); err != nil {
+		return 0, 0, fmt.Errorf("failed to create skills directory: %w", err)
+	}
+
+	var installed, skipped int
+	for _, skill := range skills {
+		wasInstalled, err := r.installSkill(skillsPath, destination, skill, force)
+		if err != nil {
+			return installed, skipped, err
+		}
+		if wasInstalled {
+			installed++
+		} else {
+			skipped++
+		}
+	}
+
+	return installed, skipped, nil
+}
+
+func (r *SkillInstallCommand) cloneAgents(path string) error {
+	res := facades.Process().WithSpinner("Downloading Goravel agents").Run("git", "clone", "--depth=1", agentsRepo, path)
+	if res.Failed() {
+		return fmt.Errorf("failed to clone goravel agents: %v", res.Error())
+	}
+
+	return nil
+}
+
+func (r *SkillInstallCommand) resolveSkills(skillsPath string, skillNames []string) ([]string, error) {
+	skillNames, err := normalizeSkillNames(skillNames)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(skillNames) == 0 {
+		return listSkills(skillsPath)
+	}
+
+	for _, skill := range skillNames {
+		info, err := os.Stat(filepath.Join(skillsPath, skill))
+		if err != nil {
+			if os.IsNotExist(err) {
+				return nil, fmt.Errorf("skill %q does not exist", skill)
+			}
+
+			return nil, fmt.Errorf("failed to inspect skill %q: %w", skill, err)
+		}
+		if !info.IsDir() {
+			return nil, fmt.Errorf("skill %q is not a directory", skill)
+		}
+	}
+
+	return skillNames, nil
+}
+
+func (r *SkillInstallCommand) installSkill(skillsPath, destination, skill string, force bool) (bool, error) {
+	source := filepath.Join(skillsPath, skill)
+	target := filepath.Join(destination, skill)
+
+	if file.Exists(target) {
+		if !force {
+			return false, nil
+		}
+
+		if err := os.RemoveAll(target); err != nil {
+			return false, fmt.Errorf("failed to remove existing skill %q: %w", skill, err)
+		}
+	}
+
+	if err := copyDirectory(source, target); err != nil {
+		return false, fmt.Errorf("failed to install skill %q: %w", skill, err)
+	}
+
+	return true, nil
+}
+
+func normalizeSkillNames(skillNames []string) ([]string, error) {
+	seen := make(map[string]bool, len(skillNames))
+	unique := make([]string, 0, len(skillNames))
+
+	for _, skill := range skillNames {
+		skill = strings.TrimSpace(skill)
+		if skill == "" {
+			continue
+		}
+		if skill == "." || skill == ".." || strings.ContainsAny(skill, `/\\`) {
+			return nil, fmt.Errorf("invalid skill name %q", skill)
+		}
+		if seen[skill] {
+			continue
+		}
+
+		seen[skill] = true
+		unique = append(unique, skill)
+	}
+
+	return unique, nil
+}
+
+func listSkills(skillsPath string) ([]string, error) {
+	entries, err := os.ReadDir(skillsPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read skills: %w", err)
+	}
+
+	skills := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() {
+			skills = append(skills, entry.Name())
+		}
+	}
+
+	return skills, nil
+}
+
+func copyDirectory(source, target string) error {
+	return filepath.WalkDir(source, func(path string, entry os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		info, err := entry.Info()
+		if err != nil {
+			return err
+		}
+
+		relativePath, err := filepath.Rel(source, path)
+		if err != nil {
+			return err
+		}
+		targetPath := filepath.Join(target, relativePath)
+
+		if entry.IsDir() {
+			return os.MkdirAll(targetPath, info.Mode())
+		}
+		if !info.Mode().IsRegular() {
+			return fmt.Errorf("unsupported file type %q", path)
+		}
+
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+
+		return os.WriteFile(targetPath, data, info.Mode())
+	})
+}
+
+func expandHomePath(path string) (string, error) {
+	if path != "~" && !strings.HasPrefix(path, "~/") {
+		return path, nil
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("failed to get home directory: %w", err)
+	}
+	if path == "~" {
+		return home, nil
+	}
+
+	return filepath.Join(home, path[2:]), nil
+}

--- a/app/console/commands/skill_install_command.go
+++ b/app/console/commands/skill_install_command.go
@@ -154,7 +154,7 @@ func (r *SkillInstallCommand) installSkills(destination string, skillNames []str
 }
 
 func (r *SkillInstallCommand) cloneAgents(path string) error {
-	res := facades.Process().WithSpinner("Downloading Goravel agents").Run("git", "clone", "--depth=1", agentsRepo, path)
+	res := facades.Process().Quietly().WithSpinner("Downloading Goravel agents").Run("git", "clone", "--depth=1", agentsRepo, path)
 	if res.Failed() {
 		return fmt.Errorf("failed to clone goravel agents: %v", res.Error())
 	}

--- a/app/console/commands/skill_install_command.go
+++ b/app/console/commands/skill_install_command.go
@@ -283,7 +283,7 @@ func copyDirectory(source, target string) error {
 }
 
 func expandHomePath(path string) (string, error) {
-	if path != "~" && !strings.HasPrefix(path, "~/") {
+	if path != "~" && !strings.HasPrefix(path, "~/") && !strings.HasPrefix(path, `~\`) {
 		return path, nil
 	}
 

--- a/app/console/commands/skill_install_command_test.go
+++ b/app/console/commands/skill_install_command_test.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"errors"
 	"io"
 	"os"
 	"path/filepath"
@@ -11,152 +12,168 @@ import (
 	mocksprocess "github.com/goravel/framework/mocks/process"
 	"github.com/goravel/framework/support/color"
 	frameworkmock "github.com/goravel/framework/testing/mock"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/suite"
 )
 
-func TestSkillInstallCommandGetDestination(t *testing.T) {
-	skillInstallCommand := NewSkillInstallCommand()
-
-	t.Run("default path", func(t *testing.T) {
-		home := t.TempDir()
-		setHomeDir(t, home)
-
-		mockContext := mocksconsole.NewContext(t)
-		mockContext.EXPECT().Option("path").Return("").Once()
-
-		destination, err := skillInstallCommand.getDestination(mockContext)
-		assert.NoError(t, err)
-		assert.Equal(t, filepath.Join(home, ".agents", "skills"), destination)
-	})
-
-	t.Run("custom home path", func(t *testing.T) {
-		home := t.TempDir()
-		setHomeDir(t, home)
-
-		mockContext := mocksconsole.NewContext(t)
-		mockContext.EXPECT().Option("path").Return("~/goravel-skills").Once()
-
-		destination, err := skillInstallCommand.getDestination(mockContext)
-		assert.NoError(t, err)
-		assert.Equal(t, filepath.Join(home, "goravel-skills"), destination)
-	})
+type SkillInstallCommandTestSuite struct {
+	suite.Suite
+	skillInstallCommand *SkillInstallCommand
 }
 
-func TestSkillInstallCommandHandleInstallAll(t *testing.T) {
-	skillInstallCommand := NewSkillInstallCommand()
-	mockProcess := frameworkmock.Factory().Process()
-	destination := filepath.Join(t.TempDir(), "skills")
+func TestSkillInstallCommandTestSuite(t *testing.T) {
+	suite.Run(t, &SkillInstallCommandTestSuite{})
+}
 
-	expectAgentsClone(t, mockProcess, map[string]string{
+func (s *SkillInstallCommandTestSuite) SetupTest() {
+	s.skillInstallCommand = NewSkillInstallCommand()
+}
+
+func (s *SkillInstallCommandTestSuite) TestGetDestinationDefaultPath() {
+	home := s.T().TempDir()
+	setHomeDir(s.T(), home)
+
+	mockContext := mocksconsole.NewContext(s.T())
+	mockContext.EXPECT().Option("path").Return("").Once()
+
+	destination, err := s.skillInstallCommand.getDestination(mockContext)
+	s.NoError(err)
+	s.Equal(filepath.Join(home, ".agents", "skills"), destination)
+}
+
+func (s *SkillInstallCommandTestSuite) TestGetDestinationCustomHomePath() {
+	home := s.T().TempDir()
+	setHomeDir(s.T(), home)
+
+	mockContext := mocksconsole.NewContext(s.T())
+	mockContext.EXPECT().Option("path").Return("~/goravel-skills").Once()
+
+	destination, err := s.skillInstallCommand.getDestination(mockContext)
+	s.NoError(err)
+	s.Equal(filepath.Join(home, "goravel-skills"), destination)
+}
+
+func (s *SkillInstallCommandTestSuite) TestGetDestinationCustomWindowsHomePath() {
+	home := s.T().TempDir()
+	setHomeDir(s.T(), home)
+
+	mockContext := mocksconsole.NewContext(s.T())
+	mockContext.EXPECT().Option("path").Return(`~\goravel-skills`).Once()
+
+	destination, err := s.skillInstallCommand.getDestination(mockContext)
+	s.NoError(err)
+	s.Equal(filepath.Join(home, "goravel-skills"), destination)
+}
+
+func (s *SkillInstallCommandTestSuite) TestHandleInstallAll() {
+	mockProcess := frameworkmock.Factory().Process()
+	destination := filepath.Join(s.T().TempDir(), "skills")
+
+	expectAgentsClone(s.T(), mockProcess, map[string]string{
 		"goravel-planning": "planning skill",
 		"goravel-testing":  "testing skill",
 	})
 
-	mockContext := newSkillInstallContext(t, destination, nil, false)
+	mockContext := newSkillInstallContext(s.T(), destination, nil, false)
 	captureOutput := color.CaptureOutput(func(w io.Writer) {
-		assert.NoError(t, skillInstallCommand.Handle(mockContext))
+		s.NoError(s.skillInstallCommand.Handle(mockContext))
 	})
 
-	assert.Contains(t, captureOutput, "Installed 2 Goravel skill(s)")
-	assert.Equal(t, "planning skill", readSkillContent(t, destination, "goravel-planning"))
-	assert.Equal(t, "testing skill", readSkillContent(t, destination, "goravel-testing"))
+	s.Contains(captureOutput, "Installed 2 Goravel skill(s)")
+	s.Equal("planning skill", readSkillContent(s.T(), destination, "goravel-planning"))
+	s.Equal("testing skill", readSkillContent(s.T(), destination, "goravel-testing"))
 }
 
-func TestSkillInstallCommandHandleInstallSelected(t *testing.T) {
-	skillInstallCommand := NewSkillInstallCommand()
+func (s *SkillInstallCommandTestSuite) TestHandleInstallSelected() {
 	mockProcess := frameworkmock.Factory().Process()
-	destination := filepath.Join(t.TempDir(), "skills")
+	destination := filepath.Join(s.T().TempDir(), "skills")
 
-	expectAgentsClone(t, mockProcess, map[string]string{
+	expectAgentsClone(s.T(), mockProcess, map[string]string{
 		"goravel-planning": "planning skill",
 		"goravel-testing":  "testing skill",
 	})
 
-	mockContext := newSkillInstallContext(t, destination, []string{"goravel-testing"}, false)
+	mockContext := newSkillInstallContext(s.T(), destination, []string{"goravel-testing"}, false)
 	captureOutput := color.CaptureOutput(func(w io.Writer) {
-		assert.NoError(t, skillInstallCommand.Handle(mockContext))
+		s.NoError(s.skillInstallCommand.Handle(mockContext))
 	})
 
-	assert.Contains(t, captureOutput, "Installed 1 Goravel skill(s)")
-	assert.Equal(t, "testing skill", readSkillContent(t, destination, "goravel-testing"))
-	assert.NoFileExists(t, filepath.Join(destination, "goravel-planning", "SKILL.md"))
+	s.Contains(captureOutput, "Installed 1 Goravel skill(s)")
+	s.Equal("testing skill", readSkillContent(s.T(), destination, "goravel-testing"))
+	s.NoFileExists(filepath.Join(destination, "goravel-planning", "SKILL.md"))
 }
 
-func TestSkillInstallCommandHandleMissingSkill(t *testing.T) {
-	skillInstallCommand := NewSkillInstallCommand()
+func (s *SkillInstallCommandTestSuite) TestHandleMissingSkill() {
 	mockProcess := frameworkmock.Factory().Process()
-	destination := filepath.Join(t.TempDir(), "skills")
+	destination := filepath.Join(s.T().TempDir(), "skills")
 
-	expectAgentsClone(t, mockProcess, map[string]string{
+	expectAgentsClone(s.T(), mockProcess, map[string]string{
 		"goravel-testing": "testing skill",
 	})
 
-	mockContext := newSkillInstallContext(t, destination, []string{"missing-skill"}, false)
+	mockContext := newSkillInstallContext(s.T(), destination, []string{"missing-skill"}, false)
 	captureOutput := color.CaptureOutput(func(w io.Writer) {
-		assert.NoError(t, skillInstallCommand.Handle(mockContext))
+		s.NoError(s.skillInstallCommand.Handle(mockContext))
 	})
 
-	assert.Contains(t, captureOutput, `skill "missing-skill" does not exist`)
-	assert.NoDirExists(t, destination)
+	s.Contains(captureOutput, `skill "missing-skill" does not exist`)
+	s.NoDirExists(destination)
 }
 
-func TestSkillInstallCommandHandleSkipExisting(t *testing.T) {
-	skillInstallCommand := NewSkillInstallCommand()
+func (s *SkillInstallCommandTestSuite) TestHandleSkipExisting() {
 	mockProcess := frameworkmock.Factory().Process()
-	destination := filepath.Join(t.TempDir(), "skills")
+	destination := filepath.Join(s.T().TempDir(), "skills")
 
-	writeSkillContent(t, destination, "goravel-testing", "old skill")
-	expectAgentsClone(t, mockProcess, map[string]string{
+	writeSkillContent(s.T(), destination, "goravel-testing", "old skill")
+	expectAgentsClone(s.T(), mockProcess, map[string]string{
 		"goravel-testing": "new skill",
 	})
 
-	mockContext := newSkillInstallContext(t, destination, []string{"goravel-testing"}, false)
+	mockContext := newSkillInstallContext(s.T(), destination, []string{"goravel-testing"}, false)
 	captureOutput := color.CaptureOutput(func(w io.Writer) {
-		assert.NoError(t, skillInstallCommand.Handle(mockContext))
+		s.NoError(s.skillInstallCommand.Handle(mockContext))
 	})
 
-	assert.Contains(t, captureOutput, "Skipped 1 existing Goravel skill(s)")
-	assert.Equal(t, "old skill", readSkillContent(t, destination, "goravel-testing"))
+	s.Contains(captureOutput, "Skipped 1 existing Goravel skill(s)")
+	s.Equal("old skill", readSkillContent(s.T(), destination, "goravel-testing"))
 }
 
-func TestSkillInstallCommandHandleForceExisting(t *testing.T) {
-	skillInstallCommand := NewSkillInstallCommand()
+func (s *SkillInstallCommandTestSuite) TestHandleForceExisting() {
 	mockProcess := frameworkmock.Factory().Process()
-	destination := filepath.Join(t.TempDir(), "skills")
+	destination := filepath.Join(s.T().TempDir(), "skills")
 
-	writeSkillContent(t, destination, "goravel-testing", "old skill")
-	expectAgentsClone(t, mockProcess, map[string]string{
+	writeSkillContent(s.T(), destination, "goravel-testing", "old skill")
+	expectAgentsClone(s.T(), mockProcess, map[string]string{
 		"goravel-testing": "new skill",
 	})
 
-	mockContext := newSkillInstallContext(t, destination, []string{"goravel-testing"}, true)
+	mockContext := newSkillInstallContext(s.T(), destination, []string{"goravel-testing"}, true)
 	captureOutput := color.CaptureOutput(func(w io.Writer) {
-		assert.NoError(t, skillInstallCommand.Handle(mockContext))
+		s.NoError(s.skillInstallCommand.Handle(mockContext))
 	})
 
-	assert.Contains(t, captureOutput, "Installed 1 Goravel skill(s)")
-	assert.Equal(t, "new skill", readSkillContent(t, destination, "goravel-testing"))
+	s.Contains(captureOutput, "Installed 1 Goravel skill(s)")
+	s.Equal("new skill", readSkillContent(s.T(), destination, "goravel-testing"))
 }
 
-func TestSkillInstallCommandHandleCloneFailure(t *testing.T) {
-	skillInstallCommand := NewSkillInstallCommand()
+func (s *SkillInstallCommandTestSuite) TestHandleCloneFailure() {
 	mockProcess := frameworkmock.Factory().Process()
-	destination := filepath.Join(t.TempDir(), "skills")
+	destination := filepath.Join(s.T().TempDir(), "skills")
+	cloneError := errors.New("clone failed")
 
 	mockProcess.EXPECT().WithSpinner("Downloading Goravel agents").Return(mockProcess).Once()
-	mockProcessResult := mocksprocess.NewResult(t)
+	mockProcessResult := mocksprocess.NewResult(s.T())
 	mockProcessResult.EXPECT().Failed().Return(true).Once()
-	mockProcessResult.EXPECT().Error().Return(assert.AnError).Once()
+	mockProcessResult.EXPECT().Error().Return(cloneError).Once()
 	mockProcess.EXPECT().Run("git", "clone", "--depth=1", agentsRepo, mock.Anything).Return(mockProcessResult).Once()
 
-	mockContext := newSkillInstallContext(t, destination, nil, false)
+	mockContext := newSkillInstallContext(s.T(), destination, nil, false)
 	captureOutput := color.CaptureOutput(func(w io.Writer) {
-		assert.NoError(t, skillInstallCommand.Handle(mockContext))
+		s.NoError(s.skillInstallCommand.Handle(mockContext))
 	})
 
-	assert.Contains(t, captureOutput, "failed to clone goravel agents")
-	assert.NoDirExists(t, destination)
+	s.Contains(captureOutput, "failed to clone goravel agents: clone failed")
+	s.NoDirExists(destination)
 }
 
 func newSkillInstallContext(t *testing.T, destination string, skills []string, force bool) *mocksconsole.Context {
@@ -194,7 +211,9 @@ func createAgentsRepo(t *testing.T, path string, skills map[string]string) {
 	t.Helper()
 
 	skillsPath := filepath.Join(path, "skills")
-	assert.NoError(t, os.MkdirAll(skillsPath, 0755))
+	if err := os.MkdirAll(skillsPath, 0755); err != nil {
+		t.Fatalf("os.MkdirAll(%q) = %v, want nil", skillsPath, err)
+	}
 	for skill, content := range skills {
 		writeSkillContent(t, skillsPath, skill, content)
 	}
@@ -203,8 +222,11 @@ func createAgentsRepo(t *testing.T, path string, skills map[string]string) {
 func readSkillContent(t *testing.T, skillsPath, skill string) string {
 	t.Helper()
 
-	content, err := os.ReadFile(filepath.Join(skillsPath, skill, "SKILL.md"))
-	assert.NoError(t, err)
+	path := filepath.Join(skillsPath, skill, "SKILL.md")
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("os.ReadFile(%q) = %v, want nil", path, err)
+	}
 
 	return string(content)
 }
@@ -213,6 +235,11 @@ func writeSkillContent(t *testing.T, skillsPath, skill, content string) {
 	t.Helper()
 
 	skillPath := filepath.Join(skillsPath, skill)
-	assert.NoError(t, os.MkdirAll(skillPath, 0755))
-	assert.NoError(t, os.WriteFile(filepath.Join(skillPath, "SKILL.md"), []byte(content), 0644))
+	if err := os.MkdirAll(skillPath, 0755); err != nil {
+		t.Fatalf("os.MkdirAll(%q) = %v, want nil", skillPath, err)
+	}
+	path := filepath.Join(skillPath, "SKILL.md")
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("os.WriteFile(%q) = %v, want nil", path, err)
+	}
 }

--- a/app/console/commands/skill_install_command_test.go
+++ b/app/console/commands/skill_install_command_test.go
@@ -161,6 +161,7 @@ func (s *SkillInstallCommandTestSuite) TestHandleCloneFailure() {
 	destination := filepath.Join(s.T().TempDir(), "skills")
 	cloneError := errors.New("clone failed")
 
+	mockProcess.EXPECT().Quietly().Return(mockProcess).Once()
 	mockProcess.EXPECT().WithSpinner("Downloading Goravel agents").Return(mockProcess).Once()
 	mockProcessResult := mocksprocess.NewResult(s.T())
 	mockProcessResult.EXPECT().Failed().Return(true).Once()
@@ -197,6 +198,7 @@ func setHomeDir(t *testing.T, home string) {
 func expectAgentsClone(t *testing.T, mockProcess *mocksprocess.Process, skills map[string]string) {
 	t.Helper()
 
+	mockProcess.EXPECT().Quietly().Return(mockProcess).Once()
 	mockProcess.EXPECT().WithSpinner("Downloading Goravel agents").Return(mockProcess).Once()
 	mockProcessResult := mocksprocess.NewResult(t)
 	mockProcessResult.EXPECT().Failed().Return(false).Once()

--- a/app/console/commands/skill_install_command_test.go
+++ b/app/console/commands/skill_install_command_test.go
@@ -20,7 +20,7 @@ func TestSkillInstallCommandGetDestination(t *testing.T) {
 
 	t.Run("default path", func(t *testing.T) {
 		home := t.TempDir()
-		t.Setenv("HOME", home)
+		setHomeDir(t, home)
 
 		mockContext := mocksconsole.NewContext(t)
 		mockContext.EXPECT().Option("path").Return("").Once()
@@ -32,7 +32,7 @@ func TestSkillInstallCommandGetDestination(t *testing.T) {
 
 	t.Run("custom home path", func(t *testing.T) {
 		home := t.TempDir()
-		t.Setenv("HOME", home)
+		setHomeDir(t, home)
 
 		mockContext := mocksconsole.NewContext(t)
 		mockContext.EXPECT().Option("path").Return("~/goravel-skills").Once()
@@ -168,6 +168,13 @@ func newSkillInstallContext(t *testing.T, destination string, skills []string, f
 	mockContext.EXPECT().OptionBool("force").Return(force).Once()
 
 	return mockContext
+}
+
+func setHomeDir(t *testing.T, home string) {
+	t.Helper()
+
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
 }
 
 func expectAgentsClone(t *testing.T, mockProcess *mocksprocess.Process, skills map[string]string) {

--- a/app/console/commands/skill_install_command_test.go
+++ b/app/console/commands/skill_install_command_test.go
@@ -1,0 +1,211 @@
+package commands
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/goravel/framework/contracts/process"
+	mocksconsole "github.com/goravel/framework/mocks/console"
+	mocksprocess "github.com/goravel/framework/mocks/process"
+	"github.com/goravel/framework/support/color"
+	frameworkmock "github.com/goravel/framework/testing/mock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestSkillInstallCommandGetDestination(t *testing.T) {
+	skillInstallCommand := NewSkillInstallCommand()
+
+	t.Run("default path", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("HOME", home)
+
+		mockContext := mocksconsole.NewContext(t)
+		mockContext.EXPECT().Option("path").Return("").Once()
+
+		destination, err := skillInstallCommand.getDestination(mockContext)
+		assert.NoError(t, err)
+		assert.Equal(t, filepath.Join(home, ".agents", "skills"), destination)
+	})
+
+	t.Run("custom home path", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("HOME", home)
+
+		mockContext := mocksconsole.NewContext(t)
+		mockContext.EXPECT().Option("path").Return("~/goravel-skills").Once()
+
+		destination, err := skillInstallCommand.getDestination(mockContext)
+		assert.NoError(t, err)
+		assert.Equal(t, filepath.Join(home, "goravel-skills"), destination)
+	})
+}
+
+func TestSkillInstallCommandHandleInstallAll(t *testing.T) {
+	skillInstallCommand := NewSkillInstallCommand()
+	mockProcess := frameworkmock.Factory().Process()
+	destination := filepath.Join(t.TempDir(), "skills")
+
+	expectAgentsClone(t, mockProcess, map[string]string{
+		"goravel-planning": "planning skill",
+		"goravel-testing":  "testing skill",
+	})
+
+	mockContext := newSkillInstallContext(t, destination, nil, false)
+	captureOutput := color.CaptureOutput(func(w io.Writer) {
+		assert.NoError(t, skillInstallCommand.Handle(mockContext))
+	})
+
+	assert.Contains(t, captureOutput, "Installed 2 Goravel skill(s)")
+	assert.Equal(t, "planning skill", readSkillContent(t, destination, "goravel-planning"))
+	assert.Equal(t, "testing skill", readSkillContent(t, destination, "goravel-testing"))
+}
+
+func TestSkillInstallCommandHandleInstallSelected(t *testing.T) {
+	skillInstallCommand := NewSkillInstallCommand()
+	mockProcess := frameworkmock.Factory().Process()
+	destination := filepath.Join(t.TempDir(), "skills")
+
+	expectAgentsClone(t, mockProcess, map[string]string{
+		"goravel-planning": "planning skill",
+		"goravel-testing":  "testing skill",
+	})
+
+	mockContext := newSkillInstallContext(t, destination, []string{"goravel-testing"}, false)
+	captureOutput := color.CaptureOutput(func(w io.Writer) {
+		assert.NoError(t, skillInstallCommand.Handle(mockContext))
+	})
+
+	assert.Contains(t, captureOutput, "Installed 1 Goravel skill(s)")
+	assert.Equal(t, "testing skill", readSkillContent(t, destination, "goravel-testing"))
+	assert.NoFileExists(t, filepath.Join(destination, "goravel-planning", "SKILL.md"))
+}
+
+func TestSkillInstallCommandHandleMissingSkill(t *testing.T) {
+	skillInstallCommand := NewSkillInstallCommand()
+	mockProcess := frameworkmock.Factory().Process()
+	destination := filepath.Join(t.TempDir(), "skills")
+
+	expectAgentsClone(t, mockProcess, map[string]string{
+		"goravel-testing": "testing skill",
+	})
+
+	mockContext := newSkillInstallContext(t, destination, []string{"missing-skill"}, false)
+	captureOutput := color.CaptureOutput(func(w io.Writer) {
+		assert.NoError(t, skillInstallCommand.Handle(mockContext))
+	})
+
+	assert.Contains(t, captureOutput, `skill "missing-skill" does not exist`)
+	assert.NoDirExists(t, destination)
+}
+
+func TestSkillInstallCommandHandleSkipExisting(t *testing.T) {
+	skillInstallCommand := NewSkillInstallCommand()
+	mockProcess := frameworkmock.Factory().Process()
+	destination := filepath.Join(t.TempDir(), "skills")
+
+	writeSkillContent(t, destination, "goravel-testing", "old skill")
+	expectAgentsClone(t, mockProcess, map[string]string{
+		"goravel-testing": "new skill",
+	})
+
+	mockContext := newSkillInstallContext(t, destination, []string{"goravel-testing"}, false)
+	captureOutput := color.CaptureOutput(func(w io.Writer) {
+		assert.NoError(t, skillInstallCommand.Handle(mockContext))
+	})
+
+	assert.Contains(t, captureOutput, "Skipped 1 existing Goravel skill(s)")
+	assert.Equal(t, "old skill", readSkillContent(t, destination, "goravel-testing"))
+}
+
+func TestSkillInstallCommandHandleForceExisting(t *testing.T) {
+	skillInstallCommand := NewSkillInstallCommand()
+	mockProcess := frameworkmock.Factory().Process()
+	destination := filepath.Join(t.TempDir(), "skills")
+
+	writeSkillContent(t, destination, "goravel-testing", "old skill")
+	expectAgentsClone(t, mockProcess, map[string]string{
+		"goravel-testing": "new skill",
+	})
+
+	mockContext := newSkillInstallContext(t, destination, []string{"goravel-testing"}, true)
+	captureOutput := color.CaptureOutput(func(w io.Writer) {
+		assert.NoError(t, skillInstallCommand.Handle(mockContext))
+	})
+
+	assert.Contains(t, captureOutput, "Installed 1 Goravel skill(s)")
+	assert.Equal(t, "new skill", readSkillContent(t, destination, "goravel-testing"))
+}
+
+func TestSkillInstallCommandHandleCloneFailure(t *testing.T) {
+	skillInstallCommand := NewSkillInstallCommand()
+	mockProcess := frameworkmock.Factory().Process()
+	destination := filepath.Join(t.TempDir(), "skills")
+
+	mockProcess.EXPECT().WithSpinner("Downloading Goravel agents").Return(mockProcess).Once()
+	mockProcessResult := mocksprocess.NewResult(t)
+	mockProcessResult.EXPECT().Failed().Return(true).Once()
+	mockProcessResult.EXPECT().Error().Return(assert.AnError).Once()
+	mockProcess.EXPECT().Run("git", "clone", "--depth=1", agentsRepo, mock.Anything).Return(mockProcessResult).Once()
+
+	mockContext := newSkillInstallContext(t, destination, nil, false)
+	captureOutput := color.CaptureOutput(func(w io.Writer) {
+		assert.NoError(t, skillInstallCommand.Handle(mockContext))
+	})
+
+	assert.Contains(t, captureOutput, "failed to clone goravel agents")
+	assert.NoDirExists(t, destination)
+}
+
+func newSkillInstallContext(t *testing.T, destination string, skills []string, force bool) *mocksconsole.Context {
+	t.Helper()
+
+	mockContext := mocksconsole.NewContext(t)
+	mockContext.EXPECT().Option("path").Return(destination).Once()
+	mockContext.EXPECT().ArgumentStringSlice("skills").Return(skills).Once()
+	mockContext.EXPECT().OptionBool("force").Return(force).Once()
+
+	return mockContext
+}
+
+func expectAgentsClone(t *testing.T, mockProcess *mocksprocess.Process, skills map[string]string) {
+	t.Helper()
+
+	mockProcess.EXPECT().WithSpinner("Downloading Goravel agents").Return(mockProcess).Once()
+	mockProcessResult := mocksprocess.NewResult(t)
+	mockProcessResult.EXPECT().Failed().Return(false).Once()
+	mockProcess.EXPECT().Run("git", "clone", "--depth=1", agentsRepo, mock.Anything).RunAndReturn(func(name string, args ...string) process.Result {
+		createAgentsRepo(t, args[3], skills)
+
+		return mockProcessResult
+	}).Once()
+}
+
+func createAgentsRepo(t *testing.T, path string, skills map[string]string) {
+	t.Helper()
+
+	skillsPath := filepath.Join(path, "skills")
+	assert.NoError(t, os.MkdirAll(skillsPath, 0755))
+	for skill, content := range skills {
+		writeSkillContent(t, skillsPath, skill, content)
+	}
+}
+
+func readSkillContent(t *testing.T, skillsPath, skill string) string {
+	t.Helper()
+
+	content, err := os.ReadFile(filepath.Join(skillsPath, skill, "SKILL.md"))
+	assert.NoError(t, err)
+
+	return string(content)
+}
+
+func writeSkillContent(t *testing.T, skillsPath, skill, content string) {
+	t.Helper()
+
+	skillPath := filepath.Join(skillsPath, skill)
+	assert.NoError(t, os.MkdirAll(skillPath, 0755))
+	assert.NoError(t, os.WriteFile(filepath.Join(skillPath, "SKILL.md"), []byte(content), 0644))
+}

--- a/app/providers/artisan_service_provider.go
+++ b/app/providers/artisan_service_provider.go
@@ -37,6 +37,7 @@ func (r *ArtisanServiceProvider) Boot(app foundation.Application) {
 	artisanFacade := app.MakeArtisan()
 	artisanFacade.Register([]contractsconsole.Command{
 		commands.NewNewCommand(),
+		commands.NewSkillInstallCommand(),
 		commands.NewUpgradeCommand(),
 	})
 }
@@ -72,7 +73,7 @@ func NewApplication() contractsconsole.Artisan {
 
 func (r *Application) Register(commands []contractsconsole.Command) {
 	for _, item := range commands {
-		if slices.Contains([]string{"list", "new", "upgrade"}, item.Signature()) {
+		if slices.Contains([]string{"list", "new", "skill:install", "upgrade"}, item.Signature()) {
 			r.commands = append(r.commands, item)
 		}
 	}


### PR DESCRIPTION
## Summary
- Adds `goravel skill:install` to install all Goravel agent skills into `~/.agents/skills` by default.
- Allows installing selected skill names and choosing a custom destination folder with `--path`.
- Preserves existing skills unless users pass `--force`.

## Why
Goravel now has a dedicated agents repository, and developers need a simple installer that brings those skills into their local agent configuration without manually cloning and copying directories. The command downloads `goravel/agents`, validates requested skill names, and copies the selected skill folders into the target skills directory.

```bash
goravel skill:install
goravel skill:install --path ~/goravel-skills
goravel skill:install goravel-testing goravel-planning
goravel skill:install --force goravel-testing
```