### PR TITLE
feat: add skill list command

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ goravel new blog
 ## Skills
 
 ```bash
+# List available Goravel agent skills
+goravel skill:list
+
 # Install all Goravel agent skills to ~/.agents/skills
 goravel skill:install
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ goravel new blog
 # List available Goravel agent skills
 goravel skill:list
 
+# List available Goravel agent skills with descriptions
+goravel skill:list --detail
+
 # Install all Goravel agent skills to ~/.agents/skills
 goravel skill:install
 

--- a/app/console/commands/skill_install_command.go
+++ b/app/console/commands/skill_install_command.go
@@ -120,7 +120,7 @@ func (r *SkillInstallCommand) installSkills(destination string, skillNames []str
 	}()
 
 	repoPath := filepath.Join(tmpDir, "agents")
-	if err := r.cloneAgents(repoPath); err != nil {
+	if err := cloneAgents(repoPath); err != nil {
 		return 0, 0, err
 	}
 
@@ -153,7 +153,7 @@ func (r *SkillInstallCommand) installSkills(destination string, skillNames []str
 	return installed, skipped, nil
 }
 
-func (r *SkillInstallCommand) cloneAgents(path string) error {
+func cloneAgents(path string) error {
 	res := facades.Process().Quietly().WithSpinner("Downloading Goravel agents").Run("git", "clone", "--depth=1", agentsRepo, path)
 	if res.Failed() {
 		return fmt.Errorf("failed to clone goravel agents: %v", res.Error())

--- a/app/console/commands/skill_list_command.go
+++ b/app/console/commands/skill_list_command.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/goravel/framework/contracts/console"
 	"github.com/goravel/framework/contracts/console/command"
@@ -12,6 +13,11 @@ import (
 )
 
 type SkillListCommand struct{}
+
+type skillDetail struct {
+	Name        string
+	Description string
+}
 
 func NewSkillListCommand() *SkillListCommand {
 	return &SkillListCommand{}
@@ -29,26 +35,43 @@ func (r *SkillListCommand) Description() string {
 
 // Extend The console command extend.
 func (r *SkillListCommand) Extend() command.Extend {
-	return command.Extend{}
+	return command.Extend{
+		Flags: []command.Flag{
+			&command.BoolFlag{
+				Name:               "detail",
+				Aliases:            []string{"d"},
+				Usage:              "Print skill details",
+				DisableDefaultText: true,
+			},
+		},
+	}
 }
 
 // Handle Execute the console command.
 func (r *SkillListCommand) Handle(ctx console.Context) error {
-	skills, err := r.fetchSkills()
+	detail := ctx.OptionBool("detail")
+	skills, err := r.fetchSkills(detail)
 	if err != nil {
 		color.Errorln(err)
 		return nil
 	}
 
-	color.Successln("Available Goravel skills:")
-	for _, skill := range skills {
-		color.Printfln("  - %s", skill)
+	color.Green().Printfln("Available Goravel skills:")
+	for index, skill := range skills {
+		if detail {
+			color.Printfln("")
+		}
+
+		color.Printfln("%d. %s", index+1, skill.Name)
+		if detail && skill.Description != "" {
+			color.Printfln("   Description: %s", skill.Description)
+		}
 	}
 
 	return nil
 }
 
-func (r *SkillListCommand) fetchSkills() ([]string, error) {
+func (r *SkillListCommand) fetchSkills(detail bool) ([]skillDetail, error) {
 	tmpDir, err := os.MkdirTemp("", "goravel-agents-*")
 	if err != nil {
 		return nil, fmt.Errorf("failed to create temp directory: %w", err)
@@ -62,7 +85,8 @@ func (r *SkillListCommand) fetchSkills() ([]string, error) {
 		return nil, err
 	}
 
-	skills, err := listSkills(filepath.Join(repoPath, "skills"))
+	skillsPath := filepath.Join(repoPath, "skills")
+	skills, err := listSkillDetails(skillsPath, detail)
 	if err != nil {
 		return nil, err
 	}
@@ -71,4 +95,74 @@ func (r *SkillListCommand) fetchSkills() ([]string, error) {
 	}
 
 	return skills, nil
+}
+
+func listSkillDetails(skillsPath string, detail bool) ([]skillDetail, error) {
+	skillNames, err := listSkills(skillsPath)
+	if err != nil {
+		return nil, err
+	}
+
+	skills := make([]skillDetail, 0, len(skillNames))
+	for _, skillName := range skillNames {
+		skill := skillDetail{Name: skillName}
+		if detail {
+			description, err := readSkillDescription(filepath.Join(skillsPath, skillName, "SKILL.md"))
+			if err != nil {
+				return nil, fmt.Errorf("failed to read skill %q detail: %w", skillName, err)
+			}
+
+			skill.Description = description
+		}
+
+		skills = append(skills, skill)
+	}
+
+	return skills, nil
+}
+
+func readSkillDescription(path string) (string, error) {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+
+	return parseSkillDescription(string(content)), nil
+}
+
+func parseSkillDescription(content string) string {
+	lines := strings.Split(content, "\n")
+	if len(lines) == 0 || strings.TrimSpace(lines[0]) != "---" {
+		return ""
+	}
+
+	var description []string
+	collectDescription := false
+	for _, line := range lines[1:] {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "---" {
+			break
+		}
+		if collectDescription {
+			if strings.HasPrefix(line, " ") || strings.HasPrefix(line, "\t") || trimmed == "" {
+				description = append(description, trimmed)
+				continue
+			}
+
+			break
+		}
+		if !strings.HasPrefix(trimmed, "description:") {
+			continue
+		}
+
+		value := strings.TrimSpace(strings.TrimPrefix(trimmed, "description:"))
+		if value == "" || strings.HasPrefix(value, ">") || strings.HasPrefix(value, "|") {
+			collectDescription = true
+			continue
+		}
+
+		return strings.Trim(value, `"'`)
+	}
+
+	return strings.Join(strings.Fields(strings.Join(description, " ")), " ")
 }

--- a/app/console/commands/skill_list_command.go
+++ b/app/console/commands/skill_list_command.go
@@ -1,0 +1,74 @@
+package commands
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/goravel/framework/contracts/console"
+	"github.com/goravel/framework/contracts/console/command"
+	"github.com/goravel/framework/support/color"
+)
+
+type SkillListCommand struct{}
+
+func NewSkillListCommand() *SkillListCommand {
+	return &SkillListCommand{}
+}
+
+// Signature The name and signature of the console command.
+func (r *SkillListCommand) Signature() string {
+	return "skill:list"
+}
+
+// Description The console command description.
+func (r *SkillListCommand) Description() string {
+	return "List available Goravel agent skills"
+}
+
+// Extend The console command extend.
+func (r *SkillListCommand) Extend() command.Extend {
+	return command.Extend{}
+}
+
+// Handle Execute the console command.
+func (r *SkillListCommand) Handle(ctx console.Context) error {
+	skills, err := r.fetchSkills()
+	if err != nil {
+		color.Errorln(err)
+		return nil
+	}
+
+	color.Successln("Available Goravel skills:")
+	for _, skill := range skills {
+		color.Printfln("  - %s", skill)
+	}
+
+	return nil
+}
+
+func (r *SkillListCommand) fetchSkills() ([]string, error) {
+	tmpDir, err := os.MkdirTemp("", "goravel-agents-*")
+	if err != nil {
+		return nil, fmt.Errorf("failed to create temp directory: %w", err)
+	}
+	defer func() {
+		_ = os.RemoveAll(tmpDir)
+	}()
+
+	repoPath := filepath.Join(tmpDir, "agents")
+	if err := cloneAgents(repoPath); err != nil {
+		return nil, err
+	}
+
+	skills, err := listSkills(filepath.Join(repoPath, "skills"))
+	if err != nil {
+		return nil, err
+	}
+	if len(skills) == 0 {
+		return nil, errors.New("no skills found in goravel/agents")
+	}
+
+	return skills, nil
+}

--- a/app/console/commands/skill_list_command_test.go
+++ b/app/console/commands/skill_list_command_test.go
@@ -1,0 +1,75 @@
+package commands
+
+import (
+	"errors"
+	"io"
+	"testing"
+
+	mocksconsole "github.com/goravel/framework/mocks/console"
+	mocksprocess "github.com/goravel/framework/mocks/process"
+	"github.com/goravel/framework/support/color"
+	frameworkmock "github.com/goravel/framework/testing/mock"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/suite"
+)
+
+type SkillListCommandTestSuite struct {
+	suite.Suite
+	skillListCommand *SkillListCommand
+}
+
+func TestSkillListCommandTestSuite(t *testing.T) {
+	suite.Run(t, &SkillListCommandTestSuite{})
+}
+
+func (s *SkillListCommandTestSuite) SetupTest() {
+	s.skillListCommand = NewSkillListCommand()
+}
+
+func (s *SkillListCommandTestSuite) TestHandleListSkills() {
+	mockProcess := frameworkmock.Factory().Process()
+	expectAgentsClone(s.T(), mockProcess, map[string]string{
+		"goravel-planning": "planning skill",
+		"goravel-testing":  "testing skill",
+	})
+
+	mockContext := mocksconsole.NewContext(s.T())
+	captureOutput := color.CaptureOutput(func(w io.Writer) {
+		s.NoError(s.skillListCommand.Handle(mockContext))
+	})
+
+	s.Contains(captureOutput, "Available Goravel skills:")
+	s.Contains(captureOutput, "  - goravel-planning")
+	s.Contains(captureOutput, "  - goravel-testing")
+}
+
+func (s *SkillListCommandTestSuite) TestHandleNoSkills() {
+	mockProcess := frameworkmock.Factory().Process()
+	expectAgentsClone(s.T(), mockProcess, map[string]string{})
+
+	mockContext := mocksconsole.NewContext(s.T())
+	captureOutput := color.CaptureOutput(func(w io.Writer) {
+		s.NoError(s.skillListCommand.Handle(mockContext))
+	})
+
+	s.Contains(captureOutput, "no skills found in goravel/agents")
+}
+
+func (s *SkillListCommandTestSuite) TestHandleCloneFailure() {
+	mockProcess := frameworkmock.Factory().Process()
+	cloneError := errors.New("clone failed")
+
+	mockProcess.EXPECT().Quietly().Return(mockProcess).Once()
+	mockProcess.EXPECT().WithSpinner("Downloading Goravel agents").Return(mockProcess).Once()
+	mockProcessResult := mocksprocess.NewResult(s.T())
+	mockProcessResult.EXPECT().Failed().Return(true).Once()
+	mockProcessResult.EXPECT().Error().Return(cloneError).Once()
+	mockProcess.EXPECT().Run("git", "clone", "--depth=1", agentsRepo, mock.Anything).Return(mockProcessResult).Once()
+
+	mockContext := mocksconsole.NewContext(s.T())
+	captureOutput := color.CaptureOutput(func(w io.Writer) {
+		s.NoError(s.skillListCommand.Handle(mockContext))
+	})
+
+	s.Contains(captureOutput, "failed to clone goravel agents: clone failed")
+}

--- a/app/console/commands/skill_list_command_test.go
+++ b/app/console/commands/skill_list_command_test.go
@@ -33,21 +33,37 @@ func (s *SkillListCommandTestSuite) TestHandleListSkills() {
 		"goravel-testing":  "testing skill",
 	})
 
-	mockContext := mocksconsole.NewContext(s.T())
+	mockContext := newSkillListContext(s.T(), false)
 	captureOutput := color.CaptureOutput(func(w io.Writer) {
 		s.NoError(s.skillListCommand.Handle(mockContext))
 	})
 
 	s.Contains(captureOutput, "Available Goravel skills:")
-	s.Contains(captureOutput, "  - goravel-planning")
-	s.Contains(captureOutput, "  - goravel-testing")
+	s.Contains(captureOutput, "1. goravel-planning")
+	s.Contains(captureOutput, "2. goravel-testing")
+	s.NotContains(captureOutput, "planning skill")
+}
+
+func (s *SkillListCommandTestSuite) TestHandleListSkillDetails() {
+	mockProcess := frameworkmock.Factory().Process()
+	expectAgentsClone(s.T(), mockProcess, map[string]string{
+		"goravel-testing": "---\nname: goravel-testing\ndescription: >\n  Goravel test-writing and test-running conventions.\n  Use this skill when adding tests.\n---\n\n# Testing",
+	})
+
+	mockContext := newSkillListContext(s.T(), true)
+	captureOutput := color.CaptureOutput(func(w io.Writer) {
+		s.NoError(s.skillListCommand.Handle(mockContext))
+	})
+
+	s.Contains(captureOutput, "1. goravel-testing")
+	s.Contains(captureOutput, "   Description: Goravel test-writing and test-running conventions. Use this skill when adding tests.")
 }
 
 func (s *SkillListCommandTestSuite) TestHandleNoSkills() {
 	mockProcess := frameworkmock.Factory().Process()
 	expectAgentsClone(s.T(), mockProcess, map[string]string{})
 
-	mockContext := mocksconsole.NewContext(s.T())
+	mockContext := newSkillListContext(s.T(), false)
 	captureOutput := color.CaptureOutput(func(w io.Writer) {
 		s.NoError(s.skillListCommand.Handle(mockContext))
 	})
@@ -66,10 +82,19 @@ func (s *SkillListCommandTestSuite) TestHandleCloneFailure() {
 	mockProcessResult.EXPECT().Error().Return(cloneError).Once()
 	mockProcess.EXPECT().Run("git", "clone", "--depth=1", agentsRepo, mock.Anything).Return(mockProcessResult).Once()
 
-	mockContext := mocksconsole.NewContext(s.T())
+	mockContext := newSkillListContext(s.T(), false)
 	captureOutput := color.CaptureOutput(func(w io.Writer) {
 		s.NoError(s.skillListCommand.Handle(mockContext))
 	})
 
 	s.Contains(captureOutput, "failed to clone goravel agents: clone failed")
+}
+
+func newSkillListContext(t *testing.T, detail bool) *mocksconsole.Context {
+	t.Helper()
+
+	mockContext := mocksconsole.NewContext(t)
+	mockContext.EXPECT().OptionBool("detail").Return(detail).Once()
+
+	return mockContext
 }

--- a/app/providers/artisan_service_provider.go
+++ b/app/providers/artisan_service_provider.go
@@ -38,6 +38,7 @@ func (r *ArtisanServiceProvider) Boot(app foundation.Application) {
 	artisanFacade.Register([]contractsconsole.Command{
 		commands.NewNewCommand(),
 		commands.NewSkillInstallCommand(),
+		commands.NewSkillListCommand(),
 		commands.NewUpgradeCommand(),
 	})
 }
@@ -73,7 +74,7 @@ func NewApplication() contractsconsole.Artisan {
 
 func (r *Application) Register(commands []contractsconsole.Command) {
 	for _, item := range commands {
-		if slices.Contains([]string{"list", "new", "skill:install", "upgrade"}, item.Signature()) {
+		if slices.Contains([]string{"list", "new", "skill:install", "skill:list", "upgrade"}, item.Signature()) {
 			r.commands = append(r.commands, item)
 		}
 	}


### PR DESCRIPTION
## Summary
- Add `goravel skill:list` to list available Goravel agent skills.
- Reuse the agents clone helper shared with `skill:install`.
- Document the command and cover success/error paths with tests.

## Why
- Users can discover available skills before choosing what to install.

## Tests
- `go test ./app/console/commands -run TestSkillListCommandTestSuite`
- `go test ./app/console/commands -run TestSkillInstallCommandTestSuite`
- `go test ./...`
- `go vet ./...`